### PR TITLE
feat: Add codemod to convert style strings to objects.

### DIFF
--- a/lib/codemods/style-string-to-object.js
+++ b/lib/codemods/style-string-to-object.js
@@ -1,0 +1,47 @@
+function camelcase(str) {
+  return str && str.replace(/-(.)/g, (m, $1) => `${$1.toUpperCase()}`);
+}
+
+function trimDanglingComma(str) {
+  return str.replace(/,$/, '');
+}
+
+function inlineStyleToObject(style) {
+  return style
+    .split(';')
+    .filter(Boolean)
+    .map((declaration) => declaration.split(':'))
+    .reduce((acc, [ key, value ]) => {
+      acc += `\n${camelcase(key.trim())}: '${value.trim()}',`;
+      return acc;
+    }, '')
+}
+
+/**
+ * Transforms styles using string literals to objects
+ * @example
+ * style="width: 100%; height: 100%"
+ * =>
+ * style={{
+ *   width: 100%,
+ *   height: 100%
+ * }}
+ */
+function transformer(file, api) {
+  const jsc = api.jscodeshift;
+  const root = jsc(file.source);
+
+  return jsc(file.source)
+    .find(jsc.JSXAttribute, (node) =>
+      (node.name && node.name.name === 'style') && (node.value && node.value.type === 'StringLiteral');
+    )
+    .forEach(path => {
+      jsc(path).replaceWith(
+        `${path.node.name.name}={{${trimDanglingComma(inlineStyleToObject(path.node.value.value))}\n}}`
+      );
+    })
+    .toSource();
+}
+
+module.exports = transformer;
+module.exports.parser = 'babylon';

--- a/lib/migrate-preact-x.js
+++ b/lib/migrate-preact-x.js
@@ -1,6 +1,7 @@
 const pragmaCodemod = require('./codemods/pragma-createElement');
 const defaultImportCodemod = require('./codemods/default-import');
 const convertProperties = require('./codemods/convert-properties');
+const styleStringtoObject = require('./codemods/style-string-to-object');
 const combineCodemods = require('./util/combineCodemods');
 
-module.exports = combineCodemods([pragmaCodemod, defaultImportCodemod, convertProperties]);
+module.exports = combineCodemods([pragmaCodemod, defaultImportCodemod, convertProperties, styleStringtoObject]);


### PR DESCRIPTION
Note that this does not preserve indentation, it relies on something like `prettier` or `eslint` to fixup the indentation after the codemod runs.

This only takes care of real string literals, not JSXExpressions.

**TODO**:
 - [ ] Tests